### PR TITLE
Fix some typos and update code for Flink 1.6

### DIFF
--- a/peel-core/src/main/scala/org/peelframework/core/config/SystemConfig.scala
+++ b/peel-core/src/main/scala/org/peelframework/core/config/SystemConfig.scala
@@ -53,7 +53,7 @@ object SystemConfig {
     private final val template = {
       val rs = Option(getClass.getResourceAsStream(templatePath))
       mc.compile(new BufferedReader(new InputStreamReader(
-        rs.getOrElse(throw new RuntimeException("Cannot find template resoure %s".format(templatePath))))))
+        rs.getOrElse(throw new RuntimeException("Cannot find template resource %s".format(templatePath))))))
     }
 
     /** Check whether file represented by this entry has changed with resepect to a given `config` instance.

--- a/peel-extensions/src/main/scala/org/peelframework/flink/beans/system/Flink.scala
+++ b/peel-extensions/src/main/scala/org/peelframework/flink/beans/system/Flink.scala
@@ -120,10 +120,12 @@ class Flink(
           // wait a bit
           Thread.sleep(config.getInt(s"system.$configKey.startup.polling.interval"))
           // get new values
-          if (version.startsWith("0.6"))
+          if (Version(version) <= Version("0.6"))
             curr = Integer.parseInt((shell !! s"""cat $logDir/flink-$user-jobmanager-*.log | grep 'Creating instance' | wc -l""").trim())
-          else
+          else if (Version(version) <= Version("1.6"))
             curr = Integer.parseInt((shell !! s"""cat $logDir/flink-$user-jobmanager-*.log | grep 'Registered TaskManager' | wc -l""").trim())
+          else
+            curr = Integer.parseInt((shell !! s"""cat $logDir/flink-$user-standalonesession-*.log | grep 'Registering TaskManager' | wc -l""").trim())
           // timeout if counter goes below zero
           cntr = cntr - 1
           if (cntr < 0) throw new SetUpTimeoutException(s"Cannot start system '$toString'; node connection timeout at system ")

--- a/peel-extensions/src/main/scala/org/peelframework/flink/beans/system/Flink.scala
+++ b/peel-extensions/src/main/scala/org/peelframework/flink/beans/system/Flink.scala
@@ -21,7 +21,7 @@ import com.samskivert.mustache.Mustache
 import org.peelframework.core.beans.system.Lifespan.Lifespan
 import org.peelframework.core.beans.system.{DistributedLogCollection, SetUpTimeoutException, System}
 import org.peelframework.core.config.{Model, SystemConfig}
-import org.peelframework.core.util.shell
+import org.peelframework.core.util.{Version, shell}
 
 import scala.collection.JavaConverters._
 import scala.collection.Seq
@@ -108,7 +108,9 @@ class Flink(
         val init = 0 // Flink resets the job manager log on startup
 
         shell ! s"${config.getString(s"system.$configKey.path.home")}/bin/start-cluster.sh"
-        shell ! s"${config.getString(s"system.$configKey.path.home")}/bin/start-webclient.sh"
+        if (Version(version) < Version("1.0")) {
+          shell ! s"${config.getString(s"system.$configKey.path.home")}/bin/start-webclient.sh"
+        }
         logger.info(s"Waiting for nodes to connect")
 
         var curr = init
@@ -143,7 +145,9 @@ class Flink(
 
   override protected def stop() = {
     shell ! s"${config.getString(s"system.$configKey.path.home")}/bin/stop-cluster.sh"
-    shell ! s"${config.getString(s"system.$configKey.path.home")}/bin/stop-webclient.sh"
+    if (Version(version) < Version("1.0")) {
+      shell ! s"${config.getString(s"system.$configKey.path.home")}/bin/stop-webclient.sh"
+    }
     shell ! s"rm -f ${config.getString(s"system.$configKey.config.yaml.env.pid.dir")}/flink-*.pid"
     isUp = false
   }

--- a/peel-extensions/src/main/scala/org/peelframework/hadoop/beans/system/HDFS2.scala
+++ b/peel-extensions/src/main/scala/org/peelframework/hadoop/beans/system/HDFS2.scala
@@ -126,7 +126,7 @@ class HDFS2(
         case e: SetUpTimeoutException =>
           failedStartUpAttempts = failedStartUpAttempts + 1
           if (failedStartUpAttempts < config.getInt(s"system.$configKey.startup.max.attempts")) {
-            shell ! s"$home/bin/stop-dfs.sh"
+            shell ! s"$home/sbin/stop-dfs.sh"
             logger.info(s"Could not bring system '$toString' up in time, trying again...")
           } else {
             throw e


### PR DESCRIPTION
Summary of changes:

- fix typo in SystemConfig.scala
- don't call start-webclient.sh on newer Flink versions
- update parsing of Flink log file to register task managers
- fix path to HDFS sbin/stop-dfs.sh